### PR TITLE
Fix github link

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
                     </li>
                     <li>
                         <a target="_blank" rel="noopener" href="https://github.com/malteriechmann?tab=repositories">
-                            github.com/malteriechmann/<strong>repositories</strong>
+                            github.com/malteriechmann?tab=<strong>repositories</strong>
                         </a>
                     </li>
                     <li>


### PR DESCRIPTION
GitHub did change the link structure, so the actual provided link does not work anymore.