### PR TITLE
Remove obsolete link

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,11 +55,6 @@
                         </a>
                     </li>
                     <li>
-                        <a target="_blank" rel="noopener" href="https://keybase.io/malteriechmann">
-                            <strong>keybase</strong>.io/malteriechmann
-                        </a>
-                    </li>
-                    <li>
                         <a target="_blank" rel="noopener" href="https://malteriechmann.de/pgp-public-key.asc">
                             malteriechmann.de/<strong>pgp</strong>-<strong>public</strong>-<strong>key</strong>.asc
                         </a>


### PR DESCRIPTION
The link is no longer available

Is it possible to add the `hacktoberfest-accepted` label?